### PR TITLE
Bump Worker.Extensions.Mcp to 1.5.0 and add input/output schema sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [remote-mcp-functions-dotnet] Changelog
 
+<a name="1.2.0"></a>
+# 1.2.0
+
+*Features*
+* Updated Microsoft.Azure.Functions.Worker.Extensions.Mcp from 1.4.0 to 1.5.0 across all sample projects (FunctionsMcpTool, FunctionsMcpResources, FunctionsMcpPrompts, McpWeatherApp, FunctionsMcpApp)
+* Added `search_snippets` tool sample in FunctionsMcpTool demonstrating the new `WithInputSchema` and `WithOutputSchema` fluent APIs for declaring explicit JSON schemas for tool inputs and structured outputs
+
 <a name="1.1.0"></a>
 # 1.1.0
 

--- a/src/FunctionsMcpApp/FunctionsMcpApp.csproj
+++ b/src/FunctionsMcpApp/FunctionsMcpApp.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0-preview.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
   </ItemGroup>
 

--- a/src/FunctionsMcpPrompts/FunctionsMcpPrompts.csproj
+++ b/src/FunctionsMcpPrompts/FunctionsMcpPrompts.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk" Version="1.0.0-preview.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
   </ItemGroup>

--- a/src/FunctionsMcpResources/FunctionsMcpResources.csproj
+++ b/src/FunctionsMcpResources/FunctionsMcpResources.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk" Version="1.0.0-preview.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />

--- a/src/FunctionsMcpTool/FunctionsMcpTool.csproj
+++ b/src/FunctionsMcpTool/FunctionsMcpTool.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk" Version="1.0.0-preview.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />

--- a/src/FunctionsMcpTool/Program.cs
+++ b/src/FunctionsMcpTool/Program.cs
@@ -25,5 +25,50 @@ builder
     .ConfigureMcpTool(EchoToolName)
     .WithProperty(EchoMessagePropertyName, McpToolPropertyType.String, EchoMessagePropertyDescription, required: true);
 
+// Demonstrate explicit JSON input and output schemas (Worker.Extensions.Mcp 1.5.0+).
+// The tool's arguments and the shape of its structured output are advertised to MCP
+// clients exactly as written here, instead of being inferred from attributes or POCOs.
+builder
+    .ConfigureMcpTool(SearchSnippetsToolName)
+    .WithInputSchema("""
+        {
+            "type": "object",
+            "properties": {
+                "prefix": {
+                    "type": "string",
+                    "description": "Snippet name prefix to match. Empty string matches all snippets."
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum number of results to return (1-100).",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 10
+                }
+            },
+            "required": ["prefix"]
+        }
+        """)
+    .WithOutputSchema("""
+        {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "The prefix that was searched."
+                },
+                "count": {
+                    "type": "integer",
+                    "description": "Number of snippets returned."
+                },
+                "results": {
+                    "type": "array",
+                    "description": "Names of matching snippets.",
+                    "items": { "type": "string" }
+                }
+            },
+            "required": ["query", "count", "results"]
+        }
+        """);
 
 builder.Build().Run();

--- a/src/FunctionsMcpTool/README.md
+++ b/src/FunctionsMcpTool/README.md
@@ -1,6 +1,6 @@
 # FunctionsMcpTool — Remote MCP Server on Azure Functions (.NET/C#)
 
-This project is a .NET 10 Azure Function app that exposes multiple MCP (Model Context Protocol) tools as a remote MCP server. It includes tools for snippets, QR code generation, badges, echo, hello, and a **hello with auth** tool that demonstrates the On-Behalf-Of (OBO) flow to call Microsoft Graph as the signed-in user.
+This project is a .NET 10 Azure Function app that exposes multiple MCP (Model Context Protocol) tools as a remote MCP server. It includes tools for snippets (including a `search_snippets` sample that declares explicit input/output JSON schemas), QR code generation, badges, echo, hello, and a **hello with auth** tool that demonstrates the On-Behalf-Of (OBO) flow to call Microsoft Graph as the signed-in user.
 
 > **Note:** MCP prompts and resource templates are in separate projects — see [FunctionsMcpPrompts](../FunctionsMcpPrompts/) and [FunctionsMcpResources](../FunctionsMcpResources/).
 

--- a/src/FunctionsMcpTool/SearchSnippetsTool.cs
+++ b/src/FunctionsMcpTool/SearchSnippetsTool.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Azure.Storage.Blobs;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Extensions.Mcp;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Protocol;
+using static FunctionsMcpTool.ToolsInformation;
+
+namespace FunctionsMcpTool;
+
+/// <summary>
+/// Demonstrates the explicit <c>WithInputSchema</c> and <c>WithOutputSchema</c>
+/// fluent APIs (added in Worker.Extensions.Mcp 1.5.0). The tool's inputs and the
+/// shape of its structured output are declared in <c>Program.cs</c> rather than
+/// inferred from <c>McpToolProperty</c> attributes or POCO bindings.
+///
+/// The function reads arguments from <see cref="ToolInvocationContext.Arguments"/>
+/// and returns a <see cref="CallToolResult"/> whose <c>StructuredContent</c>
+/// matches the advertised output schema.
+/// </summary>
+internal class SearchSnippetsTool(ILogger<SearchSnippetsTool> logger)
+{
+    private static BlobServiceClient GetBlobServiceClient() =>
+        new(Environment.GetEnvironmentVariable("AzureWebJobsStorage"));
+
+    [Function(nameof(SearchSnippets))]
+    public async Task<CallToolResult> SearchSnippets(
+        [McpToolTrigger(SearchSnippetsToolName, SearchSnippetsToolDescription)]
+            ToolInvocationContext context
+    )
+    {
+        var prefix = context.Arguments?.GetValueOrDefault(SearchPrefixPropertyName)?.ToString() ?? string.Empty;
+        var limit = context.Arguments?.GetValueOrDefault(SearchLimitPropertyName) switch
+        {
+            null => 10,
+            JsonElement { ValueKind: JsonValueKind.Number } e => e.GetInt32(),
+            var v => int.TryParse(v.ToString(), out var parsed) ? parsed : 10
+        };
+        limit = Math.Clamp(limit, 1, 100);
+
+        logger.LogInformation(
+            "Searching snippets with prefix '{Prefix}' (limit {Limit})", prefix, limit);
+
+        var container = GetBlobServiceClient().GetBlobContainerClient("snippets");
+        await container.CreateIfNotExistsAsync();
+
+        var matches = new List<string>();
+        await foreach (var blob in container.GetBlobsAsync(prefix: prefix))
+        {
+            if (matches.Count >= limit)
+            {
+                break;
+            }
+
+            var name = blob.Name.EndsWith(".json", StringComparison.OrdinalIgnoreCase)
+                ? blob.Name[..^".json".Length]
+                : blob.Name;
+            matches.Add(name);
+        }
+
+        var structured = new JsonObject
+        {
+            ["query"] = prefix,
+            ["count"] = matches.Count,
+            ["results"] = new JsonArray(matches.Select(n => (JsonNode)JsonValue.Create(n)!).ToArray())
+        };
+
+        var summary = matches.Count == 0
+            ? $"No snippets found matching '{prefix}'."
+            : $"Found {matches.Count} snippet(s): {string.Join(", ", matches)}";
+
+        return new CallToolResult
+        {
+            Content = [new TextContentBlock { Text = summary }],
+            StructuredContent = structured
+        };
+    }
+}

--- a/src/FunctionsMcpTool/ToolsInformation.cs
+++ b/src/FunctionsMcpTool/ToolsInformation.cs
@@ -56,6 +56,13 @@ internal sealed class ToolsInformation
     public const string BadgeColorPropertyName = "color";
     public const string BadgeColorPropertyDescription = "Hex color for the value background (e.g., '#4CAF50' for green). Defaults to green.";
 
+    // Search snippets tool (demonstrates WithInputSchema / WithOutputSchema)
+    public const string SearchSnippetsToolName = "search_snippets";
+    public const string SearchSnippetsToolDescription =
+        "Searches saved snippets by name prefix. Demonstrates explicit JSON input and output schemas configured in Program.cs.";
+    public const string SearchPrefixPropertyName = "prefix";
+    public const string SearchLimitPropertyName = "limit";
+
     // Website preview tool
     public const string GetWebsitePreviewToolName = "get_website_preview";
     public const string GetWebsitePreviewToolDescription =

--- a/src/McpWeatherApp/McpWeatherApp.csproj
+++ b/src/McpWeatherApp/McpWeatherApp.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Mcp" Version="1.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Blobs" Version="6.8.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
   </ItemGroup>


### PR DESCRIPTION
## Summary

Adopts [`Microsoft.Azure.Functions.Worker.Extensions.Mcp` 1.5.0](https://github.com/Azure/azure-functions-mcp-extension/releases/tag/worker-1.5.0) across all sample projects and adds a new tool sample demonstrating the new explicit `WithInputSchema` and `WithOutputSchema` fluent APIs.

## Package bumps

`Microsoft.Azure.Functions.Worker.Extensions.Mcp`:

| Project | From | To |
| --- | --- | --- |
| `FunctionsMcpTool` | 1.4.0 | 1.5.0 |
| `FunctionsMcpResources` | 1.4.0 | 1.5.0 |
| `FunctionsMcpPrompts` | 1.4.0 | 1.5.0 |
| `McpWeatherApp` | 1.4.0 | 1.5.0 |
| `FunctionsMcpApp` | 1.5.0-preview.1 | 1.5.0 |

`Microsoft.Azure.Functions.Worker.Extensions.Mcp.Sdk` is already on the latest published `1.0.0-preview.4`.

## New schema sample (`FunctionsMcpTool`)

- New `SearchSnippetsTool` with a `search_snippets` function that lists snippets in blob storage by name prefix and returns a `CallToolResult` with `StructuredContent` matching the advertised output schema.
- Wired up in `Program.cs` using the new fluent APIs:
  - `WithInputSchema(...)`: `prefix` (required string) and `limit` (1-100 integer, default 10).
  - `WithOutputSchema(...)`: `query`, `count`, and `results[]` as required structured output.
- Added matching constants to `ToolsInformation.cs`.

## Docs

- `CHANGELOG.md`: new `1.2.0` entry.
- `src/FunctionsMcpTool/README.md`: mentions the new `search_snippets` schema sample.

## Verification

All 5 sample projects build cleanly with the new package version, no new warnings or errors introduced.