### PR TITLE
Make Azure Monitor exporter conditional for local dev

### DIFF
--- a/src/FunctionsMcpApp/Program.cs
+++ b/src/FunctionsMcpApp/Program.cs
@@ -11,9 +11,13 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+var otel = builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    otel.UseAzureMonitorExporter();
+}
 
 // ─── MCP App: HelloApp ─────────────────────────────────────────────
 // Simple app with a file-backed view and a title.

--- a/src/FunctionsMcpPrompts/Program.cs
+++ b/src/FunctionsMcpPrompts/Program.cs
@@ -11,9 +11,13 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+var otel = builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    otel.UseAzureMonitorExporter();
+}
 
 // Configure prompt arguments in Program.cs
 // without requiring McpPromptArgument input binding attributes:

--- a/src/FunctionsMcpResources/Program.cs
+++ b/src/FunctionsMcpResources/Program.cs
@@ -11,9 +11,13 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+var otel = builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    otel.UseAzureMonitorExporter();
+}
 
 // Configure metadata on resources:
 builder

--- a/src/FunctionsMcpTool/Program.cs
+++ b/src/FunctionsMcpTool/Program.cs
@@ -12,9 +12,13 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+var otel = builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    otel.UseAzureMonitorExporter();
+}
 
 builder.Services.AddSingleton(_ => new BlobServiceClient(
     Environment.GetEnvironmentVariable("AzureWebJobsStorage")));

--- a/src/McpWeatherApp/Program.cs
+++ b/src/McpWeatherApp/Program.cs
@@ -10,8 +10,12 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+var otel = builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults();
+
+if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING")))
+{
+    otel.UseAzureMonitorExporter();
+}
 
 builder.Build().Run();


### PR DESCRIPTION
## Problem
All 5 projects crash on `func start` locally because `UseAzureMonitorExporter()` requires `APPLICATIONINSIGHTS_CONNECTION_STRING`, which is only set in Azure (provisioned by bicep).

## Fix
Made the exporter conditional — only wire it up when the connection string env var is present. OpenTelemetry + `UseFunctionsWorkerDefaults()` still initializes; telemetry in Azure is unaffected.

### Files changed
- `src/FunctionsMcpApp/Program.cs`
- `src/FunctionsMcpPrompts/Program.cs`
- `src/FunctionsMcpResources/Program.cs`
- `src/FunctionsMcpTool/Program.cs`
- `src/McpWeatherApp/Program.cs`