### PR TITLE
Fix BlobInput binding expression in resource template sample

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -85,7 +85,10 @@
 			"type": "pickString",
 			"description": "Which project do you want to debug?",
 			"options": [
+				"FunctionsMcpApp",
 				"FunctionsMcpTool",
+				"FunctionsMcpResources",
+				"FunctionsMcpPrompts",
 				"McpWeatherApp"
 			],
 			"default": "FunctionsMcpTool"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Updated Microsoft.Azure.Functions.Worker.Extensions.Mcp from 1.4.0 to 1.5.0 across all sample projects (FunctionsMcpTool, FunctionsMcpResources, FunctionsMcpPrompts, McpWeatherApp, FunctionsMcpApp)
 * Added `search_snippets` tool sample in FunctionsMcpTool demonstrating the new `WithInputSchema` and `WithOutputSchema` fluent APIs for declaring explicit JSON schemas for tool inputs and structured outputs
 
+*Bug Fixes*
+* Fixed `[BlobInput]` binding expression in `FunctionsMcpResources.GetSnippetResource` to use `{Name}` instead of the non-existent `{mcpresourceargs.Name}` (URI template parameters from `[McpResourceTrigger]` are flattened directly into binding data)
+
 <a name="1.1.0"></a>
 # 1.1.0
 

--- a/src/FunctionsMcpResources/Program.cs
+++ b/src/FunctionsMcpResources/Program.cs
@@ -3,14 +3,17 @@ using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using static FunctionsMcpResources.ResourcesInformation;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Azure.Functions.Worker.OpenTelemetry;
+using OpenTelemetry;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services
-    .AddApplicationInsightsTelemetryWorkerService()
-    .ConfigureFunctionsApplicationInsights();
+builder.Services.AddOpenTelemetry()
+    .UseFunctionsWorkerDefaults()
+    .UseAzureMonitorExporter();
 
 // Configure metadata on resources:
 builder

--- a/src/FunctionsMcpResources/Program.cs
+++ b/src/FunctionsMcpResources/Program.cs
@@ -3,17 +3,14 @@ using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using static FunctionsMcpResources.ResourcesInformation;
-using Azure.Monitor.OpenTelemetry.Exporter;
-using Microsoft.Azure.Functions.Worker.OpenTelemetry;
-using OpenTelemetry;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-// builder.Services.AddOpenTelemetry()
-//     .UseFunctionsWorkerDefaults()
-//     .UseAzureMonitorExporter();
+builder.Services
+    .AddApplicationInsightsTelemetryWorkerService()
+    .ConfigureFunctionsApplicationInsights();
 
 // Configure metadata on resources:
 builder

--- a/src/FunctionsMcpResources/Program.cs
+++ b/src/FunctionsMcpResources/Program.cs
@@ -11,9 +11,9 @@ var builder = FunctionsApplication.CreateBuilder(args);
 
 builder.ConfigureFunctionsWebApplication();
 
-builder.Services.AddOpenTelemetry()
-    .UseFunctionsWorkerDefaults()
-    .UseAzureMonitorExporter();
+// builder.Services.AddOpenTelemetry()
+//     .UseFunctionsWorkerDefaults()
+//     .UseAzureMonitorExporter();
 
 // Configure metadata on resources:
 builder

--- a/src/FunctionsMcpResources/README.md
+++ b/src/FunctionsMcpResources/README.md
@@ -218,14 +218,14 @@ public string? GetSnippetResource(
         Description = SnippetResourceDescription,
         MimeType = "application/json")]
         ResourceInvocationContext context,
-    [BlobInput("snippets/{mcpresourceargs.Name}.json")]
+    [BlobInput("snippets/{Name}.json")]
         string? snippetContent)
 {
     return snippetContent;
 }
 ```
 
-The `{mcpresourceargs.Name}` binding expression automatically extracts the `Name` parameter from the resource URI and passes it to the blob input binding.
+URI template parameters from `[McpResourceTrigger]` (here, `Name` from `snippet://{Name}`) are flattened directly into the binding data, so `{Name}` in the `[BlobInput]` expression automatically resolves to the value supplied by the client.
 
 ## Next Steps
 

--- a/src/FunctionsMcpResources/ResourceTemplateSamples.cs
+++ b/src/FunctionsMcpResources/ResourceTemplateSamples.cs
@@ -21,7 +21,7 @@ public class ResourceTemplateSamples(ILogger<ResourceTemplateSamples> logger)
             Description = SnippetResourceDescription,
             MimeType = "application/json")]
             ResourceInvocationContext context,
-        [BlobInput("snippets/{mcpresourceargs.Name}.json")]
+        [BlobInput("snippets/{Name}.json")]
             string? snippetContent)
     {
         logger.LogInformation("Snippet resource template invoked: {Uri}", context.Uri);


### PR DESCRIPTION
## Problem

`FunctionsMcpResources.GetSnippetResource` used `[BlobInput("snippets/{mcpresourceargs.Name}.json")]`, but the MCP extension does not expose an `mcpresourceargs` binding data key.

Decompiling `Microsoft.Azure.Functions.Extensions.Mcp` 1.5.0 (`McpResourceTriggerBinding`) confirms URI template parameters from `[McpResourceTrigger]` are flattened directly into the binding data dictionary. Only tool and prompt triggers expose grouped `mcptoolargs` / `mcppromptargs` dictionaries.

## Fix

- `ResourceTemplateSamples.cs`: `{mcpresourceargs.Name}` → `{Name}`
- `FunctionsMcpResources/README.md`: updated code snippet and explanation
- `CHANGELOG.md`: added bug fix entry under 1.2.0

## Validation

`dotnet build src/FunctionsMcpResources/FunctionsMcpResources.csproj` succeeds with 0 warnings / 0 errors.