### PR TITLE
Fix DOM-based XSS in dashboard rendering

### DIFF
--- a/src/FunctionsMcpApp/app/src/dashboard-app.ts
+++ b/src/FunctionsMcpApp/app/src/dashboard-app.ts
@@ -41,7 +41,15 @@ function renderTiles(data: DashboardData): void {
   for (const t of tiles) {
     const tile = document.createElement("div");
     tile.className = "tile";
-    tile.innerHTML = `<h3>${t.label}</h3><div class="value">${t.value}</div>`;
+
+    const heading = document.createElement("h3");
+    heading.textContent = t.label;
+
+    const value = document.createElement("div");
+    value.className = "value";
+    value.textContent = t.value;
+
+    tile.append(heading, value);
     tilesContainer.appendChild(tile);
   }
 }
@@ -69,10 +77,20 @@ function renderChart(data: DashboardData): void {
     const pct = (v / maxVal) * 100;
     const group = document.createElement("div");
     group.className = "bar-group";
-    group.innerHTML = `
-      <span class="bar-value">${v}</span>
-      <div class="bar" style="height: ${Math.max(pct, 2)}%"></div>
-      <span class="bar-label">${lbl(metric)}</span>`;
+
+    const value = document.createElement("span");
+    value.className = "bar-value";
+    value.textContent = String(v);
+
+    const bar = document.createElement("div");
+    bar.className = "bar";
+    bar.style.height = `${Math.max(pct, 2)}%`;
+
+    const label = document.createElement("span");
+    label.className = "bar-label";
+    label.textContent = lbl(metric);
+
+    group.append(value, bar, label);
     chart.appendChild(group);
   }
 }


### PR DESCRIPTION
## Why this change is needed

The dashboard parses data received from an MCP tool result and renders it in the browser. This data crosses a trust boundary and must not be interpreted as HTML.

Previously, metric labels, metric values, and tile values were interpolated directly into `innerHTML`. A malicious value such as `<img src=x onerror="...">` would create a real DOM element and execute its event handler, resulting in DOM-based cross-site scripting within the dashboard iframe.

TypeScript types do not prevent this because the values originate from runtime JSON and may not match the declared interfaces.

## What changed

- Replaced `innerHTML` interpolation in `renderChart` with explicit DOM element creation.
- Replaced `innerHTML` interpolation in `renderTiles` with explicit DOM element creation.
- Assigned tool-result values through `textContent`, ensuring they are rendered only as text.
- Assigned the chart bar height directly through the typed `style.height` property.

## Testing

- Built the Vite/TypeScript dashboard successfully.
- Restored and built `FunctionsMcpApp.csproj` with 0 warnings and 0 errors.
- Started the Azure Functions host locally with Azurite.
- Invoked `SnippetDashboard` and confirmed the dashboard renders correctly.